### PR TITLE
Add support for running hugo locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
+# Local bin/cache
+.local
+
+# Build site
 site/public
 site/resources
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   # Set to fail on errors
   - set -o errexit && set -o pipefail
   # Install Hugo
-  - .travis/install_hugo.sh
+  - .travis/install_hugo.sh "${HOME}/.local"
   # Install AWS CLI
   - .travis/install_awscli.sh
   # Install Hunspell

--- a/.travis/install_hugo.sh
+++ b/.travis/install_hugo.sh
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
 
-set -o verbose
+#set -o verbose
 set -o errexit
 set -o pipefail
 
-curl -L --output 'hugo_extended_Linux-64bit.tar.gz' "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz"
-sha256sum 'hugo_extended_Linux-64bit.tar.gz'
-echo "${HUGO_HASH}  hugo_extended_Linux-64bit.tar.gz" | sha256sum -c
-tar -xvf 'hugo_extended_Linux-64bit.tar.gz' 'hugo'
-rm 'hugo_extended_Linux-64bit.tar.gz'
+echo "HUGO_VERSION=${HUGO_VERSION}"
+echo "HUGO_HASH=${HUGO_HASH}"
 
-mkdir -p "${HOME}/.local/bin"
-mv 'hugo' "${HOME}/.local/bin/hugo"
-chmod +x "${HOME}/.local/bin/hugo"
+CACHE_DIR="${1}/cache"
+CACHE_TAR="${CACHE_DIR}/hugo_extended_Linux-64bit.tar.gz"
+
+echo "CACHE_DIR=${CACHE_DIR}"
+echo "CACHE_TAR=${CACHE_TAR}"
+
+mkdir -p "${CACHE_DIR}"
+curl -L --output "${CACHE_TAR}" --time-cond "${CACHE_TAR}" \
+	"https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz"
+sha256sum "${CACHE_TAR}"
+echo "${HUGO_HASH}  ${CACHE_TAR}" | sha256sum -c
+tar -xvf "${CACHE_TAR}" 'hugo'
+
+mkdir -p "${1}/bin"
+mv 'hugo' "${1}/bin/hugo"
+chmod +x "${1}/bin/hugo"

--- a/local-hugo
+++ b/local-hugo
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -o verbose
+set -o errexit
+set -o pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+
+git submodule update --init --recursive
+
+eval "$(cd "${ROOT_DIR}" && python3 -c 'from yaml import load; [print("export {}".format(x)) for x in load(open(".travis.yml", "r"))["env"]["global"]]')"
+
+echo "HUGO_VERSION=${HUGO_VERSION}"
+echo "HUGO_HASH=${HUGO_HASH}"
+
+${ROOT_DIR}/.travis/install_hugo.sh "${ROOT_DIR}/.local"
+
+export PATH="${ROOT_DIR}/.local/bin:${PATH}"
+
+hugo ${@}

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -6,6 +6,7 @@
                 <a href="https://twitter.com/tenementjazz"><span class="fab fa-twitter fa-3x px-2"></span></a>
                 <a href="https://en-gb.facebook.com/tenementjazzband/"><span class="fab fa-facebook fa-3x px-2"></span></a>
                 <a href="https://tenementjazzband.bandcamp.com/releases"><span class="fab fa-bandcamp fa-3x px-2"></span></a>
+                <a href="https://www.instagram.com/tenementjazzband/"><span class="fab fa-instagram fa-3x px-2"></span></a>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
This add a script _local_hugo_ that runs hugo in a way that makes it identical to the Travis build.

This adds the Instagram footer to test out the build.