### PR TITLE
Add tour dates and clean up with shortcodes

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -26,4 +26,4 @@ In their brief existence so far they have performed at Aberdeen, Edinburgh, Dund
 	<i>New Orleans Wiggle</i> by <i>Tenement Jazz Band</i> now available from <a href="https://tenementjazzband.bandcamp.com/releases"><span class="fab fa-bandcamp"></span>/TenementJazzBand</a>.
 </p>
 
-{{< bandcamp 1900500612 "mx-auto embeded-bootcamp-iframe" >}}
+{{< bandcamp album="1900500612" class="mx-auto embeded-bootcamp-iframe" href="http://tenementjazzband.bandcamp.com/album/new-orleans-wiggle" alt="New Orleans Wiggle by Tenement Jazz Band" >}}

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -12,6 +12,11 @@ Their aims are to capture the raw energy and excitement of the early jazz record
 In their brief existence so far they have performed at Aberdeen, Edinburgh, Dundee and Glasgow Jazz Festivals, collaborated with various musicians via their own Cellar Session residency, and performed their own hit show on the Edinburgh Fringe telling the story of the 'Red Hot Roots of Jazz' from turn of the century New Orleans and beyond.
 
 
+## Tour Dates
+
+{{< songkick 9406004 "Tenement Jazz Band" >}}
+
+
 ## New EP Available Now
 
 [<img src="ep_cover.jpg" class="img-fluid d-block mx-auto" alt="EP album cover">](https://tenementjazzband.bandcamp.com/releases)
@@ -21,4 +26,4 @@ In their brief existence so far they have performed at Aberdeen, Edinburgh, Dund
 	<i>New Orleans Wiggle</i> by <i>Tenement Jazz Band</i> now available from <a href="https://tenementjazzband.bandcamp.com/releases"><span class="fab fa-bandcamp"></span>/TenementJazzBand</a>.
 </p>
 
-<iframe class="mx-auto embeded-bootcamp-iframe" src="https://bandcamp.com/EmbeddedPlayer/album=1900500612/size=large/bgcol=ffffff/linkcol=0687f5/artwork=small/transparent=true/" seamless><a href="http://tenementjazzband.bandcamp.com/album/new-orleans-wiggle">New Orleans Wiggle by Tenement Jazz Band</a></iframe>
+{{< bandcamp 1900500612 "mx-auto embeded-bootcamp-iframe" >}}

--- a/site/layouts/shortcodes/bandcamp.html
+++ b/site/layouts/shortcodes/bandcamp.html
@@ -1,0 +1,6 @@
+{{ $album_id := .Get 0 }}
+{{ $css_class := .Get 1 }}
+
+<iframe src="https://bandcamp.com/EmbeddedPlayer/album={{ $album_id }}/size=large/bgcol=ffffff/linkcol=0687f5/artwork=small/transparent=true/" class="{{ $css_class }}" seamless>
+    <a href="http://tenementjazzband.bandcamp.com/album/new-orleans-wiggle">New Orleans Wiggle by Tenement Jazz Band</a>
+</iframe>

--- a/site/layouts/shortcodes/bandcamp.html
+++ b/site/layouts/shortcodes/bandcamp.html
@@ -1,6 +1,3 @@
-{{ $album_id := .Get 0 }}
-{{ $css_class := .Get 1 }}
-
-<iframe src="https://bandcamp.com/EmbeddedPlayer/album={{ $album_id }}/size=large/bgcol=ffffff/linkcol=0687f5/artwork=small/transparent=true/" class="{{ $css_class }}" seamless>
-    <a href="http://tenementjazzband.bandcamp.com/album/new-orleans-wiggle">New Orleans Wiggle by Tenement Jazz Band</a>
+<iframe src="https://bandcamp.com/EmbeddedPlayer/album={{ .Get "album" }}/size=large/bgcol=ffffff/linkcol=0687f5/artwork=small/transparent=true/" {{ with .Get "class"}}class="{{.}}"{{ end }} seamless>
+    <a href="{{ .Get "href" }}">{{ .Get "alt" }}</a>
 </iframe>

--- a/site/layouts/shortcodes/songkick.html
+++ b/site/layouts/shortcodes/songkick.html
@@ -1,0 +1,5 @@
+{{ $artist_number := .Get 0 }}
+{{ $artist_name := .Get 1 }}
+
+<a href="https://www.songkick.com/artists/{{ $artist_number }}" class="songkick-widget" data-theme="dark" data-track-button="on" data-detect-style="true" data-background-color="transparent">{{ $artist_name }} tour dates</a>
+<script src="https://widget.songkick.com/{{ $artist_number }}/widget.js"></script>


### PR DESCRIPTION
Add Songkick tour dates to the home page and clean up Bandcamp and
Songkick embed codes by using shortcodes.

Fixes Issue #6